### PR TITLE
Add Curvature Functions and Drone Pair

### DIFF
--- a/sketchalgorithmautogaussian.cpp
+++ b/sketchalgorithmautogaussian.cpp
@@ -888,7 +888,7 @@ std::vector<double> compute_curvature_derivative(const std::vector<double>& x,
     // Compute dk_ds
     std::vector<double> dk_ds(k.size(), 0.0);
     for (size_t i = 0; i < k.size(); ++i) {
-        dk_ds[i] = dk[i] / ds_mid[i];
+        dk_ds[i] = std::pow(dk[i] / ds_mid[i], 2);
     }
 
     return dk_ds;


### PR DESCRIPTION
Here is the updated C++ file with the functions needed to calculate curvature, and the DronePair class.

I had to update the get_pseudo_inverse function and a few of the other helper functions to accommodate a 3x3 matrix for the Hessian calculation.

gradient_LSQ:
As I was thinking about how to update this function, I believe this function does not require the curvature information. The curvature code will need to be used in clockwise/ counterclockwise to define the critical path ($(\nabla ' \kappa)^2 = 0$ and determine what side of the path drones are on. I believe it will also be used in CrossPlume's getCross function. 
When a pair of drones crosses the critical path, it will learn the gradient of the path at that point. Currently this is learned by computing the gradient using a point prior to, on the crossing point, and after the crossing point. I believe since the drones are following a path, just as in boundary sketch, this function should remain the same. I believe the "oracle" info from getCross and clockwise/counterclockwise are where the curvature info is necessary. If this isn't the correct understanding, my apologies and I'll be happy to update the code!
